### PR TITLE
Networking pancake

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,93 +135,98 @@ fn setup(
 }
 
 fn spoof_xr_components(mut commands: Commands) {
-    commands.spawn((Transform::default(), OpenXRLeftEye));
-    commands.spawn((Transform::default(), OpenXRRightEye));
+    commands.spawn((Transform::from_xyz(1.0, 2.0, 1.1), OpenXRLeftEye));
+    commands.spawn((Transform::from_xyz(1.0, 2.0, 0.9), OpenXRRightEye));
 
-    let mut define = |ty: HandBone| {
+    let mut define_l = |ty: HandBone| {
         commands
-            .spawn((Transform::default(), OpenXRTracker, ty))
+            .spawn((Transform::from_xyz(1.0, 1.0, 1.5), OpenXRTracker, ty))
             .id()
     };
 
-    let hands = HandsResource {
-        left: HandResource {
-            palm: define(HandBone::Palm),
-            wrist: define(HandBone::Wrist),
-            thumb: ThumbResource {
-                metacarpal: define(HandBone::ThumbMetacarpal),
-                proximal: define(HandBone::ThumbProximal),
-                distal: define(HandBone::ThumbDistal),
-                tip: define(HandBone::ThumbTip),
-            },
-            index: IndexResource {
-                metacarpal: define(HandBone::IndexMetacarpal),
-                proximal: define(HandBone::IndexProximal),
-                intermediate: define(HandBone::IndexProximal),
-                distal: define(HandBone::IndexDistal),
-                tip: define(HandBone::IndexTip),
-            },
-            middle: MiddleResource {
-                metacarpal: define(HandBone::MiddleMetacarpal),
-                proximal: define(HandBone::MiddleProximal),
-                intermediate: define(HandBone::MiddleProximal),
-                distal: define(HandBone::MiddleDistal),
-                tip: define(HandBone::MiddleTip),
-            },
-            ring: RingResource {
-                metacarpal: define(HandBone::RingMetacarpal),
-                proximal: define(HandBone::RingProximal),
-                intermediate: define(HandBone::RingProximal),
-                distal: define(HandBone::RingDistal),
-                tip: define(HandBone::RingTip),
-            },
-            little: LittleResource {
-                metacarpal: define(HandBone::LittleMetacarpal),
-                proximal: define(HandBone::LittleProximal),
-                intermediate: define(HandBone::LittleProximal),
-                distal: define(HandBone::LittleDistal),
-                tip: define(HandBone::LittleTip),
-            },
+    let left = HandResource {
+        palm: define_l(HandBone::Palm),
+        wrist: define_l(HandBone::Wrist),
+        thumb: ThumbResource {
+            metacarpal: define_l(HandBone::ThumbMetacarpal),
+            proximal: define_l(HandBone::ThumbProximal),
+            distal: define_l(HandBone::ThumbDistal),
+            tip: define_l(HandBone::ThumbTip),
         },
-        right: HandResource {
-            palm: define(HandBone::Palm),
-            wrist: define(HandBone::Wrist),
-            thumb: ThumbResource {
-                metacarpal: define(HandBone::ThumbMetacarpal),
-                proximal: define(HandBone::ThumbProximal),
-                distal: define(HandBone::ThumbDistal),
-                tip: define(HandBone::ThumbTip),
-            },
-            index: IndexResource {
-                metacarpal: define(HandBone::IndexMetacarpal),
-                proximal: define(HandBone::IndexProximal),
-                intermediate: define(HandBone::IndexProximal),
-                distal: define(HandBone::IndexDistal),
-                tip: define(HandBone::IndexTip),
-            },
-            middle: MiddleResource {
-                metacarpal: define(HandBone::MiddleMetacarpal),
-                proximal: define(HandBone::MiddleProximal),
-                intermediate: define(HandBone::MiddleProximal),
-                distal: define(HandBone::MiddleDistal),
-                tip: define(HandBone::MiddleTip),
-            },
-            ring: RingResource {
-                metacarpal: define(HandBone::RingMetacarpal),
-                proximal: define(HandBone::RingProximal),
-                intermediate: define(HandBone::RingProximal),
-                distal: define(HandBone::RingDistal),
-                tip: define(HandBone::RingTip),
-            },
-            little: LittleResource {
-                metacarpal: define(HandBone::LittleMetacarpal),
-                proximal: define(HandBone::LittleProximal),
-                intermediate: define(HandBone::LittleProximal),
-                distal: define(HandBone::LittleDistal),
-                tip: define(HandBone::LittleTip),
-            },
-        }
+        index: IndexResource {
+            metacarpal: define_l(HandBone::IndexMetacarpal),
+            proximal: define_l(HandBone::IndexProximal),
+            intermediate: define_l(HandBone::IndexProximal),
+            distal: define_l(HandBone::IndexDistal),
+            tip: define_l(HandBone::IndexTip),
+        },
+        middle: MiddleResource {
+            metacarpal: define_l(HandBone::MiddleMetacarpal),
+            proximal: define_l(HandBone::MiddleProximal),
+            intermediate: define_l(HandBone::MiddleProximal),
+            distal: define_l(HandBone::MiddleDistal),
+            tip: define_l(HandBone::MiddleTip),
+        },
+        ring: RingResource {
+            metacarpal: define_l(HandBone::RingMetacarpal),
+            proximal: define_l(HandBone::RingProximal),
+            intermediate: define_l(HandBone::RingProximal),
+            distal: define_l(HandBone::RingDistal),
+            tip: define_l(HandBone::RingTip),
+        },
+        little: LittleResource {
+            metacarpal: define_l(HandBone::LittleMetacarpal),
+            proximal: define_l(HandBone::LittleProximal),
+            intermediate: define_l(HandBone::LittleProximal),
+            distal: define_l(HandBone::LittleDistal),
+            tip: define_l(HandBone::LittleTip),
+        },
     };
 
-    commands.insert_resource(hands);
+    let mut define_r = |ty: HandBone| {
+        commands
+            .spawn((Transform::from_xyz(1.0, 1.0, 0.5), OpenXRTracker, ty))
+            .id()
+    };
+
+    let right = HandResource {
+        palm: define_r(HandBone::Palm),
+        wrist: define_r(HandBone::Wrist),
+        thumb: ThumbResource {
+            metacarpal: define_r(HandBone::ThumbMetacarpal),
+            proximal: define_r(HandBone::ThumbProximal),
+            distal: define_r(HandBone::ThumbDistal),
+            tip: define_r(HandBone::ThumbTip),
+        },
+        index: IndexResource {
+            metacarpal: define_r(HandBone::IndexMetacarpal),
+            proximal: define_r(HandBone::IndexProximal),
+            intermediate: define_r(HandBone::IndexProximal),
+            distal: define_r(HandBone::IndexDistal),
+            tip: define_r(HandBone::IndexTip),
+        },
+        middle: MiddleResource {
+            metacarpal: define_r(HandBone::MiddleMetacarpal),
+            proximal: define_r(HandBone::MiddleProximal),
+            intermediate: define_r(HandBone::MiddleProximal),
+            distal: define_r(HandBone::MiddleDistal),
+            tip: define_r(HandBone::MiddleTip),
+        },
+        ring: RingResource {
+            metacarpal: define_r(HandBone::RingMetacarpal),
+            proximal: define_r(HandBone::RingProximal),
+            intermediate: define_r(HandBone::RingProximal),
+            distal: define_r(HandBone::RingDistal),
+            tip: define_r(HandBone::RingTip),
+        },
+        little: LittleResource {
+            metacarpal: define_r(HandBone::LittleMetacarpal),
+            proximal: define_r(HandBone::LittleProximal),
+            intermediate: define_r(HandBone::LittleProximal),
+            distal: define_r(HandBone::LittleDistal),
+            tip: define_r(HandBone::LittleTip),
+        },
+    };
+
+    commands.insert_resource(HandsResource { left, right });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,13 @@ use bevy_ggrs::GgrsConfig;
 use bevy_oxr::graphics::extensions::XrExtensions;
 use bevy_oxr::graphics::{XrAppInfo, XrPreferdBlendMode};
 use bevy_oxr::xr_input::debug_gizmos::OpenXrDebugRenderer;
-use bevy_oxr::xr_input::hands::common::{HandInputDebugRenderer, OpenXrHandInput};
+use bevy_oxr::xr_input::hands::common::{
+    HandInputDebugRenderer, HandResource, HandsResource, IndexResource, LittleResource,
+    MiddleResource, OpenXrHandInput, RingResource, ThumbResource,
+};
+use bevy_oxr::xr_input::hands::HandBone;
+use bevy_oxr::xr_input::trackers::{OpenXRLeftEye, OpenXRRightEye, OpenXRTracker};
+use bevy_oxr::xr_input::xr_camera::XrCameraType;
 use bevy_oxr::DefaultXrPlugins;
 use bytemuck::{Pod, Zeroable};
 use network::NetworkPlugin;
@@ -37,26 +43,34 @@ pub fn main() {
     let mut app = App::new();
     app.add_systems(Startup, setup)
         .add_plugins(LogDiagnosticsPlugin::default())
-        .add_plugins(FrameTimeDiagnosticsPlugin);
-    let mut reqeusted_extensions = XrExtensions::default();
-    reqeusted_extensions
-        .enable_fb_passthrough()
-        .enable_hand_tracking();
+        .add_plugins(FrameTimeDiagnosticsPlugin)
+        .add_plugins(NetworkPlugin);
 
-    app.add_plugins(DefaultXrPlugins {
-        reqeusted_extensions,
-        prefered_blend_mode: XrPreferdBlendMode::AlphaBlend,
-        app_info: XrAppInfo {
-            name: "wizARds".to_string(),
-        },
-    })
-    .add_plugins(OpenXrHandInput)
-    .add_plugins(OpenXrDebugRenderer)
-    .add_plugins(HandInputDebugRenderer)
-    .add_plugins(NetworkPlugin)
-    // app.add_plugins(DefaultPlugins)
-    //     .add_systems(Startup, spawn_camera)
-    ;
+    #[cfg(target_os = "android")]
+    {
+        let mut reqeusted_extensions = XrExtensions::default();
+        reqeusted_extensions
+            .enable_fb_passthrough()
+            .enable_hand_tracking();
+
+        app.add_plugins(DefaultXrPlugins {
+            reqeusted_extensions,
+            prefered_blend_mode: XrPreferdBlendMode::AlphaBlend,
+            app_info: XrAppInfo {
+                name: "wizARds".to_string(),
+            },
+        })
+        .add_plugins(OpenXrHandInput)
+        .add_plugins(OpenXrDebugRenderer)
+        .add_plugins(HandInputDebugRenderer)
+    }
+
+    #[cfg(not(target_os = "android"))]
+    {
+        app.add_plugins(DefaultPlugins)
+            .add_systems(Startup, spawn_camera)
+            .add_systems(Startup, spoof_xr_components);
+    }
 
     app.run()
 }
@@ -118,4 +132,96 @@ fn setup(
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..default()
     });
+}
+
+fn spoof_xr_components(mut commands: Commands) {
+    commands.spawn((Transform::default(), OpenXRLeftEye));
+    commands.spawn((Transform::default(), OpenXRRightEye));
+
+    let mut define = |ty: HandBone| {
+        commands
+            .spawn((Transform::default(), OpenXRTracker, ty))
+            .id()
+    };
+
+    let hands = HandsResource {
+        left: HandResource {
+            palm: define(HandBone::Palm),
+            wrist: define(HandBone::Wrist),
+            thumb: ThumbResource {
+                metacarpal: define(HandBone::ThumbMetacarpal),
+                proximal: define(HandBone::ThumbProximal),
+                distal: define(HandBone::ThumbDistal),
+                tip: define(HandBone::ThumbTip),
+            },
+            index: IndexResource {
+                metacarpal: define(HandBone::IndexMetacarpal),
+                proximal: define(HandBone::IndexProximal),
+                intermediate: define(HandBone::IndexProximal),
+                distal: define(HandBone::IndexDistal),
+                tip: define(HandBone::IndexTip),
+            },
+            middle: MiddleResource {
+                metacarpal: define(HandBone::MiddleMetacarpal),
+                proximal: define(HandBone::MiddleProximal),
+                intermediate: define(HandBone::MiddleProximal),
+                distal: define(HandBone::MiddleDistal),
+                tip: define(HandBone::MiddleTip),
+            },
+            ring: RingResource {
+                metacarpal: define(HandBone::RingMetacarpal),
+                proximal: define(HandBone::RingProximal),
+                intermediate: define(HandBone::RingProximal),
+                distal: define(HandBone::RingDistal),
+                tip: define(HandBone::RingTip),
+            },
+            little: LittleResource {
+                metacarpal: define(HandBone::LittleMetacarpal),
+                proximal: define(HandBone::LittleProximal),
+                intermediate: define(HandBone::LittleProximal),
+                distal: define(HandBone::LittleDistal),
+                tip: define(HandBone::LittleTip),
+            },
+        },
+        right: HandResource {
+            palm: define(HandBone::Palm),
+            wrist: define(HandBone::Wrist),
+            thumb: ThumbResource {
+                metacarpal: define(HandBone::ThumbMetacarpal),
+                proximal: define(HandBone::ThumbProximal),
+                distal: define(HandBone::ThumbDistal),
+                tip: define(HandBone::ThumbTip),
+            },
+            index: IndexResource {
+                metacarpal: define(HandBone::IndexMetacarpal),
+                proximal: define(HandBone::IndexProximal),
+                intermediate: define(HandBone::IndexProximal),
+                distal: define(HandBone::IndexDistal),
+                tip: define(HandBone::IndexTip),
+            },
+            middle: MiddleResource {
+                metacarpal: define(HandBone::MiddleMetacarpal),
+                proximal: define(HandBone::MiddleProximal),
+                intermediate: define(HandBone::MiddleProximal),
+                distal: define(HandBone::MiddleDistal),
+                tip: define(HandBone::MiddleTip),
+            },
+            ring: RingResource {
+                metacarpal: define(HandBone::RingMetacarpal),
+                proximal: define(HandBone::RingProximal),
+                intermediate: define(HandBone::RingProximal),
+                distal: define(HandBone::RingDistal),
+                tip: define(HandBone::RingTip),
+            },
+            little: LittleResource {
+                metacarpal: define(HandBone::LittleMetacarpal),
+                proximal: define(HandBone::LittleProximal),
+                intermediate: define(HandBone::LittleProximal),
+                distal: define(HandBone::LittleDistal),
+                tip: define(HandBone::LittleTip),
+            },
+        }
+    };
+
+    commands.insert_resource(hands);
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -67,7 +67,7 @@ impl Plugin for NetworkPlugin {
             .set_rollback_schedule_fps(FPS)
             .add_systems(ReadInputs, read_local_inputs)
             .rollback_component_with_clone::<Transform>()
-            // TODO add further components that need rollback
+            // TODO add components that need rollback
             // add your GGRS session
             .insert_resource(Session::P2P(sess))
             // TODO remove these systems and have players be instantiated in a different plugin


### PR DESCRIPTION
This lets the rollback networking code be spoofed by a client that isn't in VR, which should help with debugging in situations where we don't have access to both of our development headsets.