### PR TITLE
Amos nitpicks

### DIFF
--- a/src/spell_control.rs
+++ b/src/spell_control.rs
@@ -152,22 +152,16 @@ fn spawn_new_spell_entities(
     inputs: Res<PlayerInputs<WizGgrsConfig>>,
     mut commands: Commands,
     player_objs: Query<&PlayerID, With<PlayerHead>>,
-    spawn_location: Res<SpellSpawnLocation>,
 ) {
     for p in player_objs.iter() {
         let input = inputs[p.handle].0;
 
-        let head_transform = Transform::from_translation(input.head_pos.lerp(input.head_pos, 0.5))
-            .with_rotation(input.head_rot);
+        let spell_transform =
+            Transform::from_translation(input.left_hand_pos.lerp(input.right_hand_pos, 0.5))
+                .with_rotation(input.head_rot);
 
         if input.spell != 0 {
-            spawn_spell(
-                &mut commands,
-                input,
-                p.handle,
-                spawn_location.0,
-                head_transform,
-            );
+            spawn_spell(&mut commands, input, p.handle, spell_transform);
         }
     }
 }

--- a/src/spells.rs
+++ b/src/spells.rs
@@ -305,7 +305,7 @@ fn handle_bomb(
 fn hand_bomb_collision(
     mut commands: Commands,
     collisions: ResMut<Collisions>,
-    mut bomb: Query<(Entity, &Transform), With<BombObj>>,
+    mut bomb: Query<(Entity, &Transform, &PlayerID), With<BombObj>>,
     hands_effect: Query<(Entity, &PlayerID), (With<HandObj>, Without<BombObj>)>,
     player_left_palms: Query<
         (Entity, &Transform, &PlayerID),
@@ -324,11 +324,12 @@ fn hand_bomb_collision(
         ),
     >,
 ) {
-    for (bomb_entity, bomb_trans) in bomb.iter_mut() {
-        for (hand_entity, hand_transform, id) in
+    for (bomb_entity, bomb_trans, bomb_p_id) in bomb.iter_mut() {
+        for (hand_entity, hand_transform, hand_p_id) in
             player_left_palms.iter().chain(player_right_palms.iter())
         {
-            if collisions.contains(bomb_entity, hand_entity) {
+            if bomb_p_id.handle == hand_p_id.handle && collisions.contains(bomb_entity, hand_entity)
+            {
                 let hand_bomb_direction =
                     (bomb_trans.translation - hand_transform.translation).normalize();
 
@@ -338,7 +339,7 @@ fn hand_bomb_collision(
                     .insert(ExternalForce::new(hand_bomb_direction / 10.0).with_persistence(false));
 
                 for (hand_effect, effect_id) in hands_effect.iter() {
-                    if effect_id.handle == id.handle {
+                    if effect_id.handle == hand_p_id.handle {
                         commands.entity(hand_effect).despawn();
                     }
                 }

--- a/src/spells.rs
+++ b/src/spells.rs
@@ -113,8 +113,7 @@ pub fn spawn_spell(
     commands: &mut Commands,
     input: PlayerInput,
     p_id: usize,
-    palm_mid_point: Vec3,
-    head_transform: Transform,
+    spell_transform: Transform,
 ) {
     let spell = input.spell.try_into().unwrap();
 
@@ -125,9 +124,8 @@ pub fn spawn_spell(
                 FireSpell,
                 PlayerID { handle: p_id },
                 SpatialBundle {
-                    transform: Transform::from_translation(palm_mid_point)
-                        .with_rotation(head_transform.rotation), // TODO currently incorrect direction, needs integrating with a proper aiming system
-                    ..Default::default()
+                    transform: spell_transform,
+                    ..default()
                 },
             ))
             .add_rollback(),
@@ -137,9 +135,8 @@ pub fn spawn_spell(
                 LightningSpell,
                 PlayerID { handle: p_id },
                 SpatialBundle {
-                    transform: Transform::from_translation(palm_mid_point)
-                        .with_rotation(head_transform.rotation), // TODO currently incorrect direction, needs integrating with a proper aiming system
-                    ..Default::default()
+                    transform: spell_transform,
+                    ..default()
                 },
             ))
             .add_rollback(),
@@ -149,9 +146,8 @@ pub fn spawn_spell(
                 ParrySpell,
                 PlayerID { handle: p_id },
                 SpatialBundle {
-                    transform: Transform::from_translation(palm_mid_point)
-                        .with_rotation(head_transform.rotation),
-                    ..Default::default()
+                    transform: spell_transform,
+                    ..default()
                 },
             ))
             .add_rollback(),
@@ -161,9 +157,8 @@ pub fn spawn_spell(
                 BombSpell,
                 PlayerID { handle: p_id },
                 SpatialBundle {
-                    transform: Transform::from_translation(palm_mid_point)
-                        .with_rotation(head_transform.rotation), // TODO currently incorrect direction, needs integrating with a proper aiming system
-                    ..Default::default()
+                    transform: spell_transform,
+                    ..default()
                 },
             ))
             .add_rollback(),
@@ -176,9 +171,8 @@ pub fn spawn_spell(
                 MissileSpell,
                 PlayerID { handle: p_id },
                 SpatialBundle {
-                    transform: Transform::from_translation(palm_mid_point)
-                        .with_rotation(head_transform.rotation), // TODO currently incorrect direction, needs integrating with a proper aiming system
-                    ..Default::default()
+                    transform: spell_transform,
+                    ..default()
                 },
             ))
             .add_rollback(),


### PR DESCRIPTION
One important change, one bug fix, and one nitpick walk into a PR, on their way to master.

The important change says "I change the way `spawn_spell_entities` gets it's initial transform to be kosher with networking."

The bug fix says "I change bombs so they can only be hit by the player that spawns them."

The nitpick says "I Change the way that "double parries" are prevented to be more sound, and allow for collapsing for loops in the `check_parry` system."

The bouncer says "Why on earth are you all entering master at the same time"

The three changes shrug.

Review plx.